### PR TITLE
Add JSON import support to load saved trees

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,15 @@
 import { useTranslation } from 'react-i18next';
+import { useRef } from 'react';
 import Canvas from './components/Canvas';
-import { useAppSelector } from './store/hooks';
-import { exportToJSON } from './utils/export';
+import { useAppDispatch, useAppSelector } from './store/hooks';
+import { load } from './store/treeSlice';
+import { exportToJSON, importFromJSON } from './utils/export';
 
 export default function App() {
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
   const state = useAppSelector((s) => s.tree.present);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleExport = () => {
     const data = exportToJSON(state);
@@ -18,9 +22,36 @@ export default function App() {
     URL.revokeObjectURL(url);
   };
 
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result;
+      if (typeof text === 'string') {
+        const parsed = importFromJSON(text);
+        dispatch(load(parsed));
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
   return (
     <div>
       <button onClick={handleExport}>{t('export')}</button>
+      <button onClick={handleImportClick}>{t('import')}</button>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <Canvas />
     </div>
   );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -14,6 +14,7 @@ i18n
           addSibling: 'Add sibling',
           addSpouse: 'Add spouse',
           export: 'Export',
+          import: 'Import',
           rootPerson: 'Root Person',
           newPerson: 'New person',
           treeCanvas: 'Tree canvas',

--- a/src/store/import.test.ts
+++ b/src/store/import.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import reducer, { load, TreeState } from './treeSlice';
+import { importFromJSON } from '../utils/export';
+
+describe('import', () => {
+  it('populates persons and relationships from JSON', () => {
+    const json = JSON.stringify({
+      persons: [
+        { id: '1', names: ['A'] },
+        { id: '2', names: ['B'] },
+      ],
+      relationships: [{ id: 'r1', type: 'partner', persons: ['1', '2'] }],
+    });
+    const parsed = importFromJSON(json);
+    const initial: TreeState = { persons: [], relationships: [] };
+    const result = reducer(initial, load(parsed));
+    expect(result.persons).toHaveLength(2);
+    expect(result.relationships).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Import button and hidden file input to load tree state from JSON
- wire import to dispatch load action and update IndexedDB
- add English i18n key for the new Import control
- test importing JSON populates persons and relationships

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68962b60cf68832db810e5f157dbeb98