### PR TITLE
refactor: use type-only import for typed selector hook

### DIFF
--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,4 +1,5 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
 import type { RootState, AppDispatch } from './index';
 
 export const useAppDispatch: () => AppDispatch = useDispatch;


### PR DESCRIPTION
## Summary
- split `TypedUseSelectorHook` into a type-only import in Redux hooks

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: 'Table' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.)*

------
https://chatgpt.com/codex/tasks/task_e_68963e5b512c832d863bbd3158119c37